### PR TITLE
prevent iTunes from launching

### DIFF
--- a/Code/QSiTunesSource.m
+++ b/Code/QSiTunesSource.m
@@ -407,10 +407,10 @@
         NSString *parentID = [thisPlaylist objectForKey:@"Parent Persistent ID"];
 		if (parentID) {
 			// this playlist is inside a folder - get the parent's name
-            NSArray *playlistResult = [[QSiTunesLibrary() playlists] filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"persistentID == %@", parentID]];
+            NSArray *playlistResult = [[library playlists] filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"%K == %@", @"Playlist Persistent ID", parentID]];
             if ([playlistResult count] > 0) {
-                iTunesPlaylist *parent = [playlistResult objectAtIndex:0];
-                label = [label stringByAppendingFormat:@" (in %@)", [parent name]];
+                NSDictionary *parent = [playlistResult objectAtIndex:0];
+                label = [label stringByAppendingFormat:@" (in %@)", [parent objectForKey:@"Name"]];
             }
 		}
 		

--- a/Info.plist
+++ b/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2.0</string>
+	<string>2.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>349</string>
+	<string>34A</string>
 	<key>NSPrincipalClass</key>
 	<string>QSiTunesObjectSource</string>
 	<key>QSActions</key>
@@ -324,7 +324,6 @@
 &lt;p&gt;Get the lyrics for the selected track.&lt;/p&gt;
 &lt;h4&gt;Play in iTunes DJ&lt;/h4&gt;
 &lt;p&gt;Add tracks to the beginning of the list in iTunes DJ and start playing.&lt;/p&gt;
-
 &lt;h4&gt;Play Next in iTunes DJ&lt;/h4&gt;
 &lt;p&gt;Add tracks after the current track in iTunes DJ.&lt;/p&gt;
 &lt;h4&gt;Add to End of iTunes DJ&lt;/h4&gt;


### PR DESCRIPTION
Silly oversight. I was using Scripting Bridge for some reason to get the name of parent playlists. I've changed it to use the in-memory library instead.

This fixes quicksilver/Quicksilver#1230
