### PR TITLE
Add "Reveal in iTunes" as alternate action for Play.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -126,6 +126,8 @@
 			<string>QSiTunesActionProvider</string>
 			<key>actionSelector</key>
 			<string>playItem:</string>
+			<key>alternateAction</key>
+			<string>QSiTunesRevealItem</string>
 			<key>directTypes</key>
 			<array>
 				<string>com.apple.itunes.track</string>


### PR DESCRIPTION
I've had a build of the plugin with this alternate action on my computer for years, partially to work around the fact that iTunes Match tracks can't be played directly: https://github.com/quicksilver/Quicksilver/issues/2058
(Revealing the track allows you to then press Enter to play in iTunes.)

I think it makes sense as a natural iTunes parallel to "Reveal" for ordinary files.